### PR TITLE
[Fix] com.ncapdevi:frag-nav dependency not found

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,6 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:1.6.0"
 
     // Fragment navigation
-    implementation 'com.ncapdevi:frag-nav:3.3.0'
+    implementation 'com.github.ncapdevi:fragnav:3.3.0'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter() // required for FragNav
+        maven { url = "https://jitpack.io" } // required for FragNav
     }
 }
 


### PR DESCRIPTION
This PR removes the old jcenter() repository and replaces it with the jitpack one. Also, the implementation of the dependency is changed from com.ncapdevi:frag-nav to com.github.ncapdevi:fragnav.

This solution is discussed [here](https://github.com/ncapdevi/FragNav/issues/255).

This fixes this [issue](https://github.com/techyourchance/android-custom-views-course/issues/1).